### PR TITLE
Clean circular rules

### DIFF
--- a/doc.mk
+++ b/doc.mk
@@ -99,8 +99,7 @@ $(foreach suf,odt ods odg odp doc docx xls xlsx ppt pptx,\
 %.png: %.xcf
 	${CONVERT.xcf.png}
 
-%.tex: %.md
-	${CONVERT.md.tex}
+# no %.md: %.tex rule
 define to_html_rule
 %.html: %.$(1)
 	${CONVERT.$(1).html}

--- a/doc.mk.nw
+++ b/doc.mk.nw
@@ -292,10 +292,10 @@ CONVERT.md.tex?=${MD2TEX} ${MD2TEXFLAGS} -o $@ $<
 TEX2MD?=        pandoc
 TEX2MDFLAGS?=   -s
 CONVERT.tex.md?=${TEX2MD} ${TEX2MDFLAGS} -o $@ $<
-@ This gives the following suffix rules.
+@ Since we occasionally want to convert TeX to Markdown, we will not provide 
+any pattern rule.
 <<MD to TeX>>=
-%.tex: %.md
-	${CONVERT.md.tex}
+# no %.md: %.tex rule
 @
 
 Sometimes we want to convert to HTML, we will use [[pandoc]] to convert both 


### PR DESCRIPTION
This removes the following pattern rules:
- `%md: %tex`