### PR TITLE
Fix noweb

### DIFF
--- a/Makefile.nw
+++ b/Makefile.nw
@@ -65,6 +65,7 @@ MAKEFILES_INCLUDE=${INCLUDE_MAKEFILES}
 The documentation depends on the main TeX file, preamble and 
 bibliographies.
 <<makefiles.pdf target>>=
+<<flags>>
 makefiles.pdf: makefiles.tex preamble.tex makefiles.bib
 makefiles.pdf: intro.tex Makefile.tex
 makefiles.pdf: exam.bib
@@ -75,6 +76,13 @@ makefiles.pdf: Dockerfile.tex
 <<clean recipe>>=
 ${RM} makefiles.pdf
 ${RM} Dockerfile.tex
+@
+
+We want to use the PythonTeX and Minted packages.
+This requires some flags to LaTeX.
+<<flags>>=
+LATEXFLAGS+=    -shell-escape
+TEX_PYTHONTEX=  yes
 @
 
 To automatically compile the documentation, we use the [[tex.mk]] include.

--- a/noweb.mk
+++ b/noweb.mk
@@ -7,7 +7,7 @@ NOWEAVE.pdf?=       \
   noweave ${NOWEAVEFLAGS.pdf} $< > ${@:.pdf=.tex} && \
   latexmk -pdf ${@:.pdf=.tex}
 NOWEAVEFLAGS.pdf?=  -x -t2
-NOTANGLEFLAGS?=
+NOTANGLEFLAGS?= -t2
 NOTANGLE?=      notangle ${NOTANGLEFLAGS} -R$(notdir $@) $(filter %.nw,$^) | \
                   ${CPIF} $@
 CPIF?=          cpif

--- a/noweb.mk
+++ b/noweb.mk
@@ -77,13 +77,6 @@ define def_weave_to_tex
 endef
 
 $(foreach suf,${NOWEB_SUFFIXES},$(eval $(call def_weave_to_tex,${suf})))
-define with_suffix_target
-%$(1): %$(1).nw
-	$${NOTANGLE$$(suffix $$@)}
-endef
-$(foreach suf,${NOWEB_SUFFIXES},$(eval $(call with_suffix_target,${suf})))
-$(addprefix %,${NOWEB_SUFFIXES}): %.nw
-	${NOTANGLE$(suffix $@)}
 %.h: %.c.nw
 	${NOTANGLE.h}
 
@@ -95,5 +88,10 @@ $(addprefix %,${NOWEB_SUFFIXES}): %.nw
 
 %.hxx: %.cxx.nw
 	${NOTANGLE.hxx}
+$(addprefix %,${NOWEB_SUFFIXES}): %.nw
+	${NOTANGLE$(suffix $@)}
+
+%: %.nw
+	${NOTANGLE$(suffix $@)}
 
 endif

--- a/noweb.mk.nw
+++ b/noweb.mk.nw
@@ -108,12 +108,6 @@ NOWEAVEFLAGS.pdf?=  -x -t2
 
 We will now cover the rules for tangling the source code for different 
 languages.
-<<suffix rules for tangling code>>=
-<<general tangling rules>>
-<<special rules for different languages>>
-@ We will first write some general pattern rules, then supply ways to adapt 
-this rule to the different languages.
-
 We will use notangle(1).
 <<variables>>=
 NOTANGLEFLAGS?= -t2
@@ -130,35 +124,39 @@ CPIF?=          cpif
 @ However, since we use this variable, cpif(1) can be substituted for tee(1) in 
 desirable situations.
 
-\paragraph{General pattern rules}
-
-There are two general pattern rules that we will add.
-<<general tangling rules>>=
-<<tangle source files with suffix>>
-<<tangle source files without suffix>>
-@ In the first one, we will tangle a file with suffix [[.suf]] from the source 
-file with suffix [[.suf.nw]] and in the second a source file with suffix 
-[[.nw]].
-
-We can start with the second.
-In this rule, we have a file with a supported suffix [[.suf]] depend on the 
-NOWEB source file with suffix [[.nw]].
-Then we let the recipe be set by the variable [[NOTANGLE.suf]], which is the 
-convention followed by make(1)~\cite[Sect.\ 10.2]{GNUMake}.
-<<tangle source files without suffix>>=
-$(addprefix %,${NOWEB_SUFFIXES}): %.nw
-	${NOTANGLE$(suffix $@)}
+We will add rules for various languages.
+The order is important, the most general rule must come last.
+<<suffix rules for tangling code>>=
+<<special rules for different languages>>
+<<general tangling rules>>
 @
 
-For the other case, we add rules using the suffix prefixed to [[.nw]].
-<<tangle source files with suffix>>=
-define with_suffix_target
-%$(1): %$(1).nw
-	$${NOTANGLE$$(suffix $$@)}
-endef
-$(foreach suf,${NOWEB_SUFFIXES},$(eval $(call with_suffix_target,${suf})))
-@ However, this rule does not capture some of the things we want, \eg we cannot 
-tangle a header file [[.h]] from a [[.cpp.nw]] file.
+\paragraph{General pattern rules}
+
+There are two general pattern rules that we will add, with double suffix 
+([[.suf.nw]] to [[.suf]]) and without ([[.nw]] to [[.suf]]).
+The first case can be captured easily with a pattern rule.
+This rule will also handle cases like [[Makefile.nw]] to [[Makefile]], 
+completely without any suffix.
+<<general tangling rules>>=
+<<tangle source files without double suffix>>
+
+%: %.nw
+	${NOTANGLE$(suffix $@)}
+@ We will add suffix-specific definitions of [[NOTANGLE]] below.
+
+For files without the double suffix, we have a file with a supported suffix 
+[[.suf]] depend on the NOWEB source file with suffix [[.nw]].
+Then we let the recipe be set by the variable [[NOTANGLE.suf]], which is the 
+convention followed by make(1)~\cite[Sect.\ 10.2]{GNUMake}.
+<<tangle source files without double suffix>>=
+$(addprefix %,${NOWEB_SUFFIXES}): %.nw
+	${NOTANGLE$(suffix $@)}
+@ This allows us to make, for example, both [[example.h]] and [[example.cpp]] 
+from [[example.nw]].
+
+However, neither of these rules capture tangling, for example, a header file 
+[[.h]] from a [[.cpp.nw]] file.
 We must add these rules manually, which we do below.
 
 \paragraph{Rules for different languages}

--- a/noweb.mk.nw
+++ b/noweb.mk.nw
@@ -110,7 +110,7 @@ We will now cover the rules for tangling the source code for different
 languages.
 We will use notangle(1).
 <<variables>>=
-NOTANGLEFLAGS?=
+NOTANGLEFLAGS?= -t2
 NOTANGLE?=      notangle ${NOTANGLEFLAGS} -R$(notdir $@) $(filter %.nw,$^) | \
                   ${CPIF} $@
 @ We will also use the command cpif(1).
@@ -239,9 +239,7 @@ NOTANGLE.hs?=       notangle ${NOTANGLEFLAGS.hs} -R$(notdir $@) \
 same reason as for the weaving, GHC automatically tangles Haskell's native 
 literate files ([[.lhs]]).
 
-Make also requires slightly modified flags.
-We need [[-t2]] to expand spaces into tabs, because make(1) requires tabs for 
-indentation, not spaces.
+Make also requires slightly modified flags:
 <<defaults for Make>>=
 NOWEB_SUFFIXES+=    .mk
 NOTANGLEFLAGS.mk?=  ${NOTANGLEFLAGS} -t2

--- a/preamble.tex
+++ b/preamble.tex
@@ -23,6 +23,9 @@
   basicstyle=\small
 }
 
+\usepackage[outputdir=ltxobj]{minted}
+\setminted{autogobble}
+
 \usepackage{noweb}
 % Needed to relax penalty for breaking code chunks across pages, otherwise 
 % there might be a lot of space following a code chunk.

--- a/tex.mk.nw
+++ b/tex.mk.nw
@@ -312,19 +312,25 @@ sub makenlo2nls {
 
 Occasionally we use PythonTeX.
 We also provide a target for the required files.
+However, this construction requires that we load PythonTeX as follows.
+\begin{minted}{LaTeX}
+\usepackage{pythontex}
+\setpythontexoutputdir{.}
+\setpythontexworkingdir{..}
+\end{minted}
+
+The code is as follows.
 <<PythonTeX files>>=
-pythontex-files-%/%.pytxmcr: pythontex-files-%
-pythontex-files-%: %.pytxcode
-	${PYTHONTEX} ${PYTHONTEXFLAGS} $<
-%.pytxcode: ${TEX_OUTDIR}/%.pytxcode
+${TEX_OUTDIR}/%.pytxcode: ${TEX_OUTDIR}/%.aux
+${TEX_OUTDIR}/%.pytxmcr: ${TEX_OUTDIR}/%.pytxcode
+  cd $(dir $@) && ${PYTHONTEX} ${PYTHONTEXFLAGS} $(notdir $@)
 @
 
 As mentioned in \cref{tex:Intro}, we can automatically add the [[.pytxmcr]] 
 file as a prerequisite if the variable [[TEX_PYTHONTEX]] is set.
 <<bibliography files>>=
 ifneq (${TEX_PYTHONTEX},)
-%.pdf: pythontex-files-%/%.pytxmcr
-${TEX_OUTDIR}/%.pdf: ${TEX_OUTDIR}/pythontex-files-%/%.pytxmcr
+${TEX_OUTDIR}/%.pdf: ${TEX_OUTDIR}/%.pytxmcr
 endif
 @
 


### PR DESCRIPTION
We should be able to have a
```make
%: %.nw
	${NOTANGLE$(suffix $@)}
```
rule. However, this conflicts with the
```make
$(addprefix %,${NOWEB_SUFFIXES}): %.nw
	${NOTANGLE$(suffix $@)}
```
rule.