### PR TITLE
Let the latexmkrc PythonTeX cus_dep use the configured interpreter

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -16,7 +16,9 @@ sub pythontex {
     # side effects in creating other files.  The dependence is a way
     # of triggering the rule to be run whenever the .pytxcode file
     # changes, and to do this before running latex/pdflatex again.
-    return system("python3 \$(which pythontex) --interpreter python:python3 --verbose \"$_[0]\"");
+    my $pythontex = $ENV{PYTHONTEX} || 'python3 $(which pythontex)';
+    my $pythontexflags = $ENV{PYTHONTEXFLAGS} // '--interpreter python:python3';
+    return system("$pythontex $pythontexflags --verbose \"$_[0]\"");
 }
 
 $pdflatex = 'internal mylatex %R %Z pdflatex %O %S';

--- a/tex.mk
+++ b/tex.mk
@@ -37,6 +37,7 @@ COMPILE.nlo?= ${MAKEINDEX} ${OUTPUT_OPTION} ${MAKEIDXFLAGS} -s nomencl.ist $<
 TEX_PYTHONTEX?=
 PYTHONTEX?=       python3 $$(which pythontex)
 PYTHONTEXFLAGS?=  --interpreter python:python3
+export PYTHONTEX PYTHONTEXFLAGS
 BIBTOOL?=     bibtool
 BIBTOOLFLAGS?=--preserve.key.case=on --print.deleted.entries=off -s -d -r biblatex
 ARCHIVE.bib?= ${CAT} $(if $(wildcard $@),$@) $% | \

--- a/tex.mk.nw
+++ b/tex.mk.nw
@@ -104,6 +104,23 @@ variables.
 <<variables>>=
 PYTHONTEX?=       python3 $$(which pythontex)
 PYTHONTEXFLAGS?=  --interpreter python:python3
+@ A document that executes its own package in [[pycode]] blocks must run
+PythonTeX under an interpreter that can import that package, which is rarely
+the bare [[python3]] on the path.
+Such a project overrides the flags in its own makefile, for instance
+\begin{lstlisting}
+PYTHONTEXFLAGS= --interpreter "python:poetry run python3"
+\end{lstlisting}
+to reach a virtualenv-managed interpreter instead.
+
+That override must also reach latexmk(1), which runs PythonTeX through a
+custom dependency of its own (\cref{tex:PythonTeX}) rather than through the
+make rules above.
+A latexmkrc is Perl read by a separate process, so it cannot see make's
+variables; exporting them turns them into environment variables, which is the
+one channel that does cross that boundary.
+<<variables>>=
+export PYTHONTEX PYTHONTEXFLAGS
 @
 
 Finally, we provide targets to easily add external classes as dependencies.
@@ -329,6 +346,7 @@ sub makenlo2nls {
 @
 
 \subsection{PythonTeX}
+\label{tex:PythonTeX}
 
 Occasionally we use PythonTeX.
 We also provide a target for the required files.
@@ -376,8 +394,40 @@ sub pythontex {
     # side effects in creating other files.  The dependence is a way
     # of triggering the rule to be run whenever the .pytxcode file
     # changes, and to do this before running latex/pdflatex again.
-    return system("python3 \$(which pythontex) --interpreter python:python3 --verbose \"$_[0]\"");
+    <<run PythonTeX with the configured interpreter>>
 }
+@
+
+Here we depart from the \ac{CTAN} original, which hardcodes its own PythonTeX
+invocation.
+Hardcoding leaves two independent paths to the same work---the make rule above
+and this custom dependency---that agree only by coincidence, and the coincidence
+breaks precisely for the projects that need PythonTeX most: the ones whose
+document imports a package that only a virtualenv interpreter can find.
+Worse, the two paths disagree silently.
+LaTeX still succeeds, latexmk still reports the custom dependency as run, and
+the only symptom is a Python traceback about a missing module, several build
+stages away from the setting that caused it.
+
+Reading the two variables back out of the environment collapses the pair into a
+single configuration point: whatever the project set in its makefile is what
+runs, on both paths.
+The literal defaults survive as Perl fallbacks so that running latexmk(1) by
+hand, with no make in the picture and hence an empty environment, behaves
+exactly as it did before.
+We distinguish unset from empty, so that a project can deliberately pass no
+flags at all without silently getting the defaults back.
+
+<<run PythonTeX with the configured interpreter>>=
+my $pythontex = $ENV{PYTHONTEX} || 'python3 $(which pythontex)';
+my $pythontexflags = $ENV{PYTHONTEXFLAGS} // '--interpreter python:python3';
+return system("$pythontex $pythontexflags --verbose \"$_[0]\"");
+@
+
+Returning to the \ac{CTAN} code, the remaining fudge is the symbolic-link
+trickery that lets the custom dependency be detected at all when [[$out_dir]]
+is in use.
+<<[[latexmkrc]]>>=
 
 $pdflatex = 'internal mylatex %R %Z pdflatex %O %S';
 $latex = 'internal mylatex %R %Z latex %O %S';


### PR DESCRIPTION
## Problem

`latexmkrc`'s PythonTeX custom dependency hardcoded its own invocation, so a project that points PythonTeX at a different interpreter was silently ignored whenever latexmk drove the build — latexmk reaches PythonTeX through the cus_dep, not through `tex.mk`'s rule.

This bites exactly the projects that need PythonTeX most: those whose document executes the package it documents, and so must run under a virtualenv interpreter that can import it. Setting

```make
PYTHONTEXFLAGS= --interpreter "python:poetry run python3"
```

in the project's makefile had no effect on the latexmk path.

`53e54b0` had already aligned the cus_dep with `tex.mk`'s *default* invocation, which fixed portability. But copying a default is not the same as sharing a configuration point — the two paths still diverge the moment anyone overrides it.

The failure is silent and remote from its cause: LaTeX succeeds, latexmk reports the cus_dep as run, and the only symptom is a Python traceback about a missing module several build stages later.

## Change

Made in `tex.mk.nw`; `tex.mk` and `latexmkrc` are regenerated.

- `tex.mk` now `export`s `PYTHONTEX` and `PYTHONTEXFLAGS`. A latexmkrc is Perl read by a separate process, so it cannot see make's variables — the environment is the one channel that crosses that boundary.
- The cus_dep reads both back from `%ENV`, keeping the literal defaults as Perl fallbacks so a hand-run `latexmk` (no make, empty environment) behaves exactly as before. `//` rather than `||` for the flags, so a project can deliberately pass no flags without silently getting the defaults back.

The `sub pythontex` body moved into its own `<<run PythonTeX with the configured interpreter>>` chunk, with prose explaining the departure from the CTAN original.

## Verification

Against `dbosk/ladok3`, whose doc build sets `PYTHONTEXFLAGS= --interpreter "python:poetry run python3"`:

| | before | after |
|---|---|---|
| `ModuleNotFoundError: No module named 'ladok3'` | 2 | 0 |
| PythonTeX | never ran | `0 error(s), 0 warning(s)`, 58 outputs |
| `make -C doc all` | Error 12 | exit 0 |
| pages | 169 (stub) | 1438 |

`perl -c latexmkrc` passes, and both tangled outputs were diffed against fresh `notangle` runs.

## Note

`make latexmkrc` in this repo does not tangle — the included `tex.mk`'s `latexmkrc:` symlink target overrides the `Makefile` tangle rule, which is #76. I tangled by hand with `notangle -R"[[latexmkrc]]" tex.mk.nw | cpif latexmkrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiBv9BVhRKCyYJJNDhiowW
